### PR TITLE
fix: toggle buttons not responding after interacting with preview iframe

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -12,7 +12,7 @@ import { ChatInterface } from "@/components/chat/ChatInterface";
 import { FileTree } from "@/components/editor/FileTree";
 import { CodeEditor } from "@/components/editor/CodeEditor";
 import { PreviewFrame } from "@/components/preview/PreviewFrame";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import { HeaderActions } from "@/components/HeaderActions";
 
 interface MainContentProps {
@@ -60,17 +60,30 @@ export function MainContent({ user, project }: MainContentProps) {
               <div className="h-full flex flex-col bg-white">
                 {/* Top Bar */}
                 <div className="h-14 border-b border-neutral-200/60 px-6 flex items-center justify-between bg-neutral-50/50">
-                  <Tabs
-                    value={activeView}
-                    onValueChange={(v) =>
-                      setActiveView(v as "preview" | "code")
-                    }
-                  >
-                    <TabsList className="bg-white/60 border border-neutral-200/60 p-0.5 h-9 shadow-sm">
-                      <TabsTrigger value="preview" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Preview</TabsTrigger>
-                      <TabsTrigger value="code" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Code</TabsTrigger>
-                    </TabsList>
-                  </Tabs>
+                  <div className="bg-white/60 border border-neutral-200/60 p-0.5 h-9 shadow-sm inline-flex items-center rounded-lg">
+                    <button
+                      onMouseDown={() => setActiveView("preview")}
+                      className={cn(
+                        "px-4 py-1.5 text-sm font-medium rounded-md transition-all",
+                        activeView === "preview"
+                          ? "bg-white text-neutral-900 shadow-sm"
+                          : "text-neutral-600"
+                      )}
+                    >
+                      Preview
+                    </button>
+                    <button
+                      onMouseDown={() => setActiveView("code")}
+                      className={cn(
+                        "px-4 py-1.5 text-sm font-medium rounded-md transition-all",
+                        activeView === "code"
+                          ? "bg-white text-neutral-900 shadow-sm"
+                          : "text-neutral-600"
+                      )}
+                    >
+                      Code
+                    </button>
+                  </div>
                   <HeaderActions user={user} projectId={project?.id} />
                 </div>
 


### PR DESCRIPTION
Fixes #2

The toggle buttons sometimes required two clicks to switch views because the preview iframe was capturing focus. The first click only blurred the iframe; the second click actually activated the button.

Replaced Radix UI Tabs (which uses `click` events) with plain buttons using `onMouseDown`, which fires before focus is transferred, making the toggle reliably work on the first click.

Generated with [Claude Code](https://claude.ai/code)